### PR TITLE
Add degeneracy threshold parameter to zero out corrections in degenerate directions

### DIFF
--- a/laser_scan_matcher/README.md
+++ b/laser_scan_matcher/README.md
@@ -34,12 +34,14 @@ IEEE International Conference on Robotics and Automation (ICRA), 2008
 | **degeneracy_cov_ramp** | `double` | Power to apply to `[0,1]` degeneracy metric prior to scaling for covariance | `5.0` | `1.0` | `10.0` |✓|
 | **degeneracy_cov_scale** | `double` | Scaling to apply to degeneracy metric for covariance along degenerate axis | `1.0` | `0.0` | `100.0` |✓|
 | **degeneracy_cov_offset** | `double` | Offset to apply to position covariance along degenerate axis | `0.0` | `0.0` | `10.0` |✓|
+| **degeneracy_threshold** | `double` | Threshold on degeneracy metric to cancel out laser correction in the degeneracy axis | `1.0` | `0.0` |`1.0` |✓|
 | **heading_cov_scale** | `double` | Scaling to apply to ICP derived heading covariance | `1.0` | `0.0` | `1e8` |✓|
 | **heading_cov_offset** | `double` | Offset to apply to ICP derived heading covariance | `0.0` | `0.0` | `10.0` |✓|
 | **min_travel_distance** | `double` | Distance in meters to trigger a new keyframe | `0.5` | `0.0` | `10.0` |✓|
 | **min_travel_heading** | `double` | Angle in degrees to trigger a new keyframe. | `30.0` | `0.0` | `180.0` |✓|
 | **odom_frame** | `string` | Which frame to track odometry in | "odom" | | |✗|
 | **publish_tf** | `bool` | Whether to publish tf transform from `odom_frame` to `base_frame` | `true` | | |✗|
+| **run_at_startup**| `bool` | Subscribe and process data at startup | `false` | | |✗|
 | **tf_timeout** | `double` | TF timeout in seconds | `0.1` | `0.0` | `10.0` |✓|
 | **xy_cov_scale** | `double` | Scaling to apply to ICP derived xy position covariance | `1.0` | `0.0` | `1e8` |✓|
 | **xy_cov_offset** | `double` | Offset to apply to ICP derived xy position covariance | `0.0` | `0.0` | `10.0` |✓|

--- a/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
+++ b/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
@@ -203,8 +203,12 @@ private:
   bool processScan(const sensor_msgs::msg::LaserScan::SharedPtr scan_msg, const tf2::Transform& pred_laser_offset);
   void laserScanToLDP(const sensor_msgs::msg::LaserScan::SharedPtr& scan, LDP& ldp);
   void createTfFromXYTheta(double x, double y, double theta, tf2::Transform& t);
+
+  void start();
   void startCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
       std::shared_ptr<std_srvs::srv::Trigger::Response> resp);
+
+  void stop();
   void stopCallback(const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
       std::shared_ptr<std_srvs::srv::Trigger::Response> resp);
 

--- a/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
+++ b/laser_scan_matcher/include/laser_scan_matcher/laser_scan_matcher.h
@@ -99,6 +99,7 @@ private:
   double degeneracy_cov_ramp_ = 5.0;
   double degeneracy_cov_scale_ = 1.0;
   double degeneracy_cov_offset_ = 0.0;
+  double degeneracy_threshold_ = 1.0;
 
   tf2::Transform base_from_laser_;  // static, cached
   tf2::Transform laser_from_base_;

--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -496,7 +496,10 @@ bool LaserScanMatcher::processScan(
     tf_broadcaster_->sendTransform (tf_msg);
   }
 
-  if (newKeyframeNeeded(corr_ch)) {
+  // get the adjusted offset of the current frame from the keyframe
+  tf2::Transform adjusted_offset = keyframe_base_in_fixed_.inverse() * base_in_fixed_;
+
+  if (newKeyframeNeeded(adjusted_offset)) {
     RCLCPP_INFO(get_logger(),"Creating new keyframe ...");
     // generate a keyframe
     ld_free(keyframe_laser_data_);

--- a/laser_scan_matcher/src/laser_scan_matcher.cpp
+++ b/laser_scan_matcher/src/laser_scan_matcher.cpp
@@ -52,7 +52,7 @@ LaserScanMatcher::LaserScanMatcher() : rclcpp::Node("laser_scan_matcher") {
   base_frame_ = param("base_frame", std::string("base_link"), "Which frame to use for the robot base");
   odom_frame_ = param("odom_frame", std::string("odom"), "Which frame to track odometry in");
   publish_tf_ =  param("publish_tf", true, "Whether to publish tf transform from 'odom_frame' to 'base_frame'");
-  bool run_at_startup =  param("run_at_startup", false, "Start in active mode");
+  bool run_at_startup =  param("run_at_startup", false, "Subscribe and process data at startup");
 
   // dynamic parameters
   register_param(&tf_timeout_, "tf_timeout", 0.1, "TF timeout in seconds.", 0.0, 10.0);
@@ -60,6 +60,7 @@ LaserScanMatcher::LaserScanMatcher() : rclcpp::Node("laser_scan_matcher") {
   register_param(&degeneracy_cov_ramp_, "degeneracy_cov_ramp", 5.0, "Power to apply to [0,1] degeneracy metric prior to scaling for covariance.", 1.0, 10.0);
   register_param(&degeneracy_cov_scale_, "degeneracy_cov_scale", 1.0, "Scaling degeneracy metric to apply to position covariance along degenerate axis", 0.0, 100.0);
   register_param(&degeneracy_cov_offset_, "degeneracy_cov_offset", 0.0, "Offset to apply to position covariance along degenerate axis", 0.0, 10.0);
+  register_param(&degeneracy_threshold_, "degeneracy_threshold", 1.0, "Threshold on degeneracy metric to cancel out laser correction in the degeneracy axis", 0.0, 1.0);
   register_param(&xy_cov_scale_, "xy_cov_scale", 1.0, "Scaling to apply to xy position covariance", 0.0, 1e8);
   register_param(&xy_cov_offset_, "xy_cov_offset", 0.0, "Offset to apply to xy position covariance", 0.0, 10.0);
   register_param(&heading_cov_scale_, "heading_cov_scale", 1.0, "Scaling to apply to heading covariance", 0.0, 1e8);
@@ -401,10 +402,17 @@ bool LaserScanMatcher::processScan(
   if (degeneracy_check_) {
     auto degenerate_axis = checkAxisDegeneracy(*curr_laser_data, 0.1, scan_msg->header.frame_id, scan_msg->header.stamp);
     float degeneracy = degenerate_axis.norm();
+    RCLCPP_DEBUG(get_logger(), "  degeneracy: %f", degeneracy);
     if (degeneracy == 0) {
       // error condition, set degenerate covariance for both axes
+      RCLCPP_WARN(get_logger(), "Setting both axes as degenerate!");
       degenerate_cov(0, 0) = degeneracy_cov_scale_ + degeneracy_cov_offset_;
-      degenerate_cov(1, 1) = degeneracy_cov_scale_ + degeneracy_cov_offset_;;
+      degenerate_cov(1, 1) = degeneracy_cov_scale_ + degeneracy_cov_offset_;
+
+      // set the pose to the predicted pose instead of the corrected pose
+      base_in_fixed_ = pred_base_in_fixed;
+
+      RCLCPP_DEBUG(get_logger(),"  adjusted base: %lf, %lf", base_in_fixed_.getOrigin().getX(), base_in_fixed_.getOrigin().getY());
     }
     else {
       // scale the degenerate axis
@@ -418,6 +426,18 @@ bool LaserScanMatcher::processScan(
       // rotate into odom frame
       auto rotation = getLaserRotation(base_in_fixed_);
       degenerate_cov = rotation * degenerate_cov * rotation.transpose();
+    }
+
+    if (degeneracy >= degeneracy_threshold_) {
+      RCLCPP_DEBUG(get_logger(), "  degeneracy %lf >= %lf", degeneracy, degeneracy_threshold_);
+      tf2::Vector3 valid_axis = tf2::Vector3(degenerate_axis.y(), -degenerate_axis.x(), 0.0).normalized();
+
+      // project correction onto the valid axis to remove any offset from the
+      // prediction in the degenerate direction
+      tf2::Vector3 correction = base_in_fixed_.getOrigin() - pred_base_in_fixed.getOrigin();
+      tf2::Vector3 adjusted_correction = correction.dot(valid_axis) * valid_axis;
+      base_in_fixed_.setOrigin(pred_base_in_fixed.getOrigin() + adjusted_correction);
+      RCLCPP_DEBUG(get_logger(),"  adjusted base: %lf, %lf", base_in_fixed_.getOrigin().getX(), base_in_fixed_.getOrigin().getY());
     }
   }
 


### PR DESCRIPTION
- Add degeneracy threshold parameter to zero out corrections in degenerate directions.
  - threshold is from 0 to 1 (the same as the degeneracy metric range)
  - defaults to 1
  - value of 0.7 seems to catch the featureless hallway case without being too sensitive
- Add parameter to begin with processing enabled

Need to test in sim